### PR TITLE
Replace literal usage of #

### DIFF
--- a/Neon/pi_leibniz_CSharp.cs
+++ b/Neon/pi_leibniz_CSharp.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace pi_leibniz_C#
+namespace pi_leibniz_CSharp
 {
     class Program
     {


### PR DESCRIPTION
@MrNeonM I replaced literal usages of "#" with the word "Sharp", otherwise it won't compile in my environment.